### PR TITLE
Adding next tick to handle the zoomer better

### DIFF
--- a/src/components/ProductZoomer.vue
+++ b/src/components/ProductZoomer.vue
@@ -169,7 +169,7 @@ export default {
     if (!["left", "right"].includes(this.options.zoomer_pane_position)) {
       throw "zoomer_pane_position is invalid";
     }
-    window.addEventListener("load", () => {
+    this.$nextTick(() => {
       this[actionName(this.options.scroller_position)]();
       this.options.injectBaseStyles = true;
       if (this.options.pane === "container-round") {


### PR DESCRIPTION
## The issue with `window.load`

The main issue is that everything inside `window.load` only runs if the Product Zoomer is there in the beginning. So, it causes issues like the ones mentioned in #54 . If the ProductZoomer is rendered later in some conditional way, it will create issues. 

## Solution
Added `this.$nextTick` instead. This will make sure the styles are added everytime the component is mounted.